### PR TITLE
Made baudrate setable

### DIFF
--- a/include/SerialPort.h
+++ b/include/SerialPort.h
@@ -24,7 +24,7 @@ private:
     COMSTAT status;
     DWORD errors;
 public:
-    SerialPort(char *portName);
+    SerialPort(char *portName, DWORD baudRate = CBR_9600);
     ~SerialPort();
 
     int readSerialPort(char *buffer, unsigned int buf_size);

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -7,7 +7,7 @@
 
 #include "SerialPort.h"
 
-SerialPort::SerialPort(char *portName)
+SerialPort::SerialPort(char *portName, DWORD baudRate)
 {
     this->connected = false;
 
@@ -34,7 +34,7 @@ SerialPort::SerialPort(char *portName)
             printf("failed to get current serial parameters");
         }
         else {
-            dcbSerialParameters.BaudRate = CBR_9600;
+            dcbSerialParameters.BaudRate = baudRate;
             dcbSerialParameters.ByteSize = 8;
             dcbSerialParameters.StopBits = ONESTOPBIT;
             dcbSerialParameters.Parity = NOPARITY;


### PR DESCRIPTION
I needed to stray away from the default 9600 baud rate setting so added that as an optional constructor parameter.
ByteSize, Stopbits and parity could probably be added like this too?